### PR TITLE
feat: 挨拶表示時に東京都の現在の天気を表示する機能を追加

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,19 +1,70 @@
 #!/usr/bin/env python3
 """
-Simple greeting script that displays the current time.
+Simple greeting script that displays the current time and Tokyo weather.
 """
 
+import json
+import urllib.request
 from datetime import datetime
+
+
+WEATHER_CODES = {
+    0: "快晴 (Clear sky)",
+    1: "晴れ (Mainly clear)",
+    2: "一部曇り (Partly cloudy)",
+    3: "曇り (Overcast)",
+    45: "霧 (Fog)",
+    48: "霧氷 (Rime fog)",
+    51: "霧雨(弱) (Light drizzle)",
+    53: "霧雨(中) (Moderate drizzle)",
+    55: "霧雨(強) (Dense drizzle)",
+    61: "小雨 (Slight rain)",
+    63: "雨 (Moderate rain)",
+    65: "大雨 (Heavy rain)",
+    71: "小雪 (Slight snow)",
+    73: "雪 (Moderate snow)",
+    75: "大雪 (Heavy snow)",
+    80: "にわか雨(弱) (Slight showers)",
+    81: "にわか雨 (Moderate showers)",
+    82: "にわか雨(強) (Violent showers)",
+    95: "雷雨 (Thunderstorm)",
+    96: "雷雨(雹あり) (Thunderstorm with hail)",
+    99: "雷雨(強い雹) (Thunderstorm with heavy hail)",
+}
+
+
+def get_tokyo_weather():
+    """Fetch current weather for Tokyo from open-meteo API."""
+    url = (
+        "https://api.open-meteo.com/v1/forecast"
+        "?latitude=35.6895&longitude=139.6917"
+        "&current_weather=true"
+        "&timezone=Asia%2FTokyo"
+    )
+    with urllib.request.urlopen(url, timeout=5) as response:
+        data = json.loads(response.read().decode())
+    current = data["current_weather"]
+    temp = current["temperature"]
+    code = current["weathercode"]
+    condition = WEATHER_CODES.get(code, f"天気コード {code}")
+    return temp, condition
 
 
 def main():
     # Get current time
     current_time = datetime.now()
-    
+
     # Display greeting with current time
     print("こんにちは！ Hello!")
     print(f"現在の時刻: {current_time.strftime('%Y年%m月%d日 %H:%M:%S')}")
     print(f"Current time: {current_time.strftime('%B %d, %Y %H:%M:%S')}")
+
+    # Display Tokyo weather
+    try:
+        temp, condition = get_tokyo_weather()
+        print(f"東京都の現在の天気: {condition}、気温 {temp}°C")
+    except Exception as e:
+        print(f"天気情報の取得に失敗しました: {e}")
 
 
 if __name__ == "__main__":

--- a/test_hello.py
+++ b/test_hello.py
@@ -5,7 +5,7 @@ Test cases for hello.py script.
 
 import unittest
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import sys
 import os
 
@@ -23,7 +23,7 @@ class TestHello(unittest.TestCase):
         """Test that greeting is displayed correctly."""
         # Mock the datetime to return a fixed time
         mock_datetime.now.return_value = datetime(2026, 3, 26, 16, 20, 9)
-        
+
         # We can't easily test print output, but we can verify the module runs
         # without error and has the expected structure
         self.assertTrue(hasattr(hello, 'main'))
@@ -34,12 +34,13 @@ class TestHello(unittest.TestCase):
         self.assertTrue(hasattr(hello, 'main'))
         self.assertTrue(callable(hello.main))
 
+    @patch('hello.get_tokyo_weather', return_value=(20.5, "晴れ (Mainly clear)"))
     @patch('builtins.print')
-    def test_main_calls_print(self, mock_print):
+    def test_main_calls_print(self, mock_print, mock_weather):
         """Test that main function calls print."""
         hello.main()
-        # Should call print at least twice (greeting and time)
-        self.assertGreaterEqual(mock_print.call_count, 2)
+        # Should call print at least 4 times (greeting, Japanese time, English time, weather)
+        self.assertGreaterEqual(mock_print.call_count, 4)
 
     def test_datetime_now_returns_datetime(self):
         """Test that datetime.now() works as expected."""
@@ -51,6 +52,33 @@ class TestHello(unittest.TestCase):
         self.assertIn('年', formatted)
         self.assertIn('月', formatted)
         self.assertIn('日', formatted)
+
+    @patch('hello.urllib.request.urlopen')
+    def test_get_tokyo_weather_success(self, mock_urlopen):
+        """Test that get_tokyo_weather returns temperature and condition."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"current_weather": {"temperature": 18.5, "weathercode": 1}}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        temp, condition = hello.get_tokyo_weather()
+        self.assertEqual(temp, 18.5)
+        self.assertIn("Mainly clear", condition)
+
+    @patch('hello.get_tokyo_weather', side_effect=Exception("network error"))
+    @patch('builtins.print')
+    def test_main_handles_weather_error(self, mock_print, mock_weather):
+        """Test that main handles weather fetch errors gracefully."""
+        hello.main()
+        printed = [str(call) for call in mock_print.call_args_list]
+        self.assertTrue(any("失敗" in s for s in printed))
+
+    def test_weather_codes_dict(self):
+        """Test that WEATHER_CODES contains common codes."""
+        self.assertIn(0, hello.WEATHER_CODES)
+        self.assertIn(3, hello.WEATHER_CODES)
+        self.assertIn(63, hello.WEATHER_CODES)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- `get_tokyo_weather()` を追加し open-meteo API（APIキー不要）で東京の現在気温・天気コードを取得
- `main()` で天気情報を日本語で表示（例：`東京都の現在の天気: 晴れ (Mainly clear)、気温 18.5°C`）
- API 失敗時はエラーメッセージを表示してグレースフルに続行

## Test plan
- [ ] `python3 -m unittest test_hello -v` で全7テスト通過を確認
- [ ] `get_tokyo_weather()` のモックテストで正常系・異常系を検証
- [ ] `WEATHER_CODES` の存在確認テストを追加

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)